### PR TITLE
Fix: Resolve JSX syntax error in Home component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { motion } from 'framer-motion'; // Import motion
 
 export default function Home() {
   return (
-    <>
+    <div>
       <Navbar />
       <section className="glass-effect py-8 px-4 mx-auto max-w-screen-xl text-center lg:py-16 lg:px-12">
         {/* The div below previously had padding/layout classes, moved them to the section tag above */}
@@ -247,7 +247,7 @@ export default function Home() {
           </span>
         </div>
       </footer>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
Wrapped Navbar, section, and footer elements within a single parent div to resolve the "Expected ',', got 'className'" error in app/page.tsx.